### PR TITLE
Updating README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,18 @@ There is no config.yml.
 There are no commands.
 
 ## What it does
+This addon will give players a separate inventory, health, food level and experience for each gamemode installed and it's corresponding worlds. It will try to allow players to play each gamemode independently of another by forbidding share of above mentioned.
 
-This will give players a separate inventory, health, food level and experience for every world they are in.
-World = over world, nether and end.
+## An example
+**BSkyBlock**'s Inventory, Health, Food level and Experience are shared only between it's corresponding worlds:
+- BSkyBlock_world
+- BSkyBlock_world_nether
+- BSkyBlock_world_the_end
 
-It is not limited to just BentoBox worlds. It applies to all worlds on the server (right now).
+**AcidIsland**'s Inventory, Health, Food level and Experience are shared only between it's corresponding worlds:
+- AcidIsland_world
+- AcidIsland_world_nether
+- BSkyBlock_world_the_end
+
+**Please note:**
+- It is not limited to just BentoBox worlds. It applies to all worlds on the server (right now).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This addon will give players a separate inventory, health, food level and experi
 **AcidIsland**'s Inventory, Health, Food level and Experience are shared only between it's corresponding worlds:
 - AcidIsland_world
 - AcidIsland_world_nether
-- BSkyBlock_world_the_end
+- AcidIsland_world_the_end
 
 **Please note:**
 - It is not limited to just BentoBox worlds. It applies to all worlds on the server (right now).


### PR DESCRIPTION
I, myself, have had a confusion when I read about the overworld, nether and end world. I thought it would give separate inventory for each world they are in.

An example: 1 for bsb_world, 1 for bsb_nether and 1 for bsb_the_end
I was about to make a feature request for this, but found out it was just me being confused.

Hope I explained it better with an example; if not, please deny my PR.