### PR TITLE
Add MC 26.1.2 to Modrinth game-versions

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -62,4 +62,5 @@ jobs:
             1.21.11
             26.1
             26.1.1
+            26.1.2
           files: target/InvSwitcher-${{ github.event.release.tag_name || inputs.tag }}.jar


### PR DESCRIPTION
Adds Minecraft `26.1.2` to the `game-versions` list in the Modrinth publish workflow, keeping the supported-versions tags current (the list already had 26.1 and 26.1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)