### PR TITLE
Release 1.19.0

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -62,4 +62,5 @@ jobs:
             1.21.11
             26.1
             26.1.1
+            26.1.2
           files: target/InvSwitcher-${{ github.event.release.tag_name || inputs.tag }}.jar

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.18.0</build.version>
+        <build.version>1.19.0</build.version>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_addon-invSwitcher</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/release-notes-1.19.0.md
+++ b/release-notes-1.19.0.md
@@ -1,0 +1,35 @@
+## 🎁 What's new
+
+1.19.0 is a follow-up to the 1.18.0 per-world economy release. It fixes two issues that stopped the new economy from working cleanly in a common setup. InvSwitcher now functions as a true **standalone economy** — you no longer need a separate economy plugin such as EssentialsX for it to take effect — and admin economy commands now report the **correct balance for offline players** instead of a stale value.
+
+## ✨ Highlights
+
+### 🐛 Standalone economy now works on its own
+InvSwitcher registers its own per-world Vault economy, but BentoBox hooks Vault during its early startup, *before* addons enable. When InvSwitcher was the only economy on the server, that early hook found nothing and was discarded, so BentoBox's `getVault()` stayed empty — and economy-dependent addons such as **Bank** disabled themselves with "Vault is required" even though a working per-world economy was present. InvSwitcher now registers a fresh Vault hook with BentoBox once its provider is live, so it works as the server's only economy.
+
+> Companion framework PRs harden this further: [BentoBox #2995](https://github.com/BentoBoxWorld/BentoBox/pull/2995) retries the Vault hook after addons enable, and [Bank #67](https://github.com/BentoBoxWorld/Bank/pull/67) retries before disabling.
+
+### 🐛 Correct balance reported for offline economy transactions
+Admin `eco give`, `eco set`, and `eco take` on an offline player reported a stale balance — for example "New balance: 0.00" right after giving 2,000. The money was always stored correctly, but the confirmation message re-read the balance from the database before the asynchronous save had flushed, returning the pre-transaction value. The commands now report the authoritative balance returned by the transaction itself.
+
+This release also hardens the underlying offline read-after-write path: offline saves are tracked while in flight so two rapid sequential transactions on the same offline player can no longer load independent stale copies and lose an update — without blocking the main thread or caching offline players indefinitely.
+
+## ⚙️ Compatibility
+
+✔️ BentoBox 3.17.0
+✔️ Paper Minecraft 1.21.5 – 26.1.2
+✔️ Java 21
+
+## 📥 How to update
+1. Take backups of your server, for safety.
+2. Stop the server.
+3. Drop the new InvSwitcher jar into the addons folder and remove the old one.
+4. Restart the server.
+5. You should be good to go!
+
+## What's Changed
+* 🐛 Register a fresh Vault hook so InvSwitcher works as a standalone economy by @tastybento in https://github.com/BentoBoxWorld/InvSwitcher/commit/d929649
+* 🐛 Report offline economy balances correctly and harden offline saves by @tastybento in https://github.com/BentoBoxWorld/InvSwitcher/commit/a15c645
+* Add MC 26.1.2 to Modrinth game-versions by @tastybento in https://github.com/BentoBoxWorld/InvSwitcher/pull/52
+
+**Full Changelog**: https://github.com/BentoBoxWorld/InvSwitcher/compare/1.18.0...1.19.0

--- a/src/main/java/com/wasteofplastic/invswitcher/InvSwitcher.java
+++ b/src/main/java/com/wasteofplastic/invswitcher/InvSwitcher.java
@@ -3,6 +3,7 @@ package com.wasteofplastic.invswitcher;
 
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -179,9 +180,20 @@ public class InvSwitcher extends Addon {
      * Re-runs BentoBox's VaultHook so it re-reads the highest-priority economy currently
      * registered with the services manager. BentoBox addons such as Bank hold this same hook
      * instance, so they pick up the change without needing to re-hook themselves.
+     * <p>
+     * If BentoBox has no stored VaultHook, its early Vault hook failed because no economy was
+     * registered when BentoBox's early hooks ran (the standalone case: we are the only economy).
+     * A failed hook is discarded by {@code HooksManager}, so {@link world.bentobox.bentobox.BentoBox#getVault()}
+     * stays empty and there is nothing to refresh. Now that our provider is live, register a fresh
+     * VaultHook so {@code getVault()} is populated for Bank and the rest of BentoBox.
      */
     private void refreshBentoBoxVaultHook() {
-        getPlugin().getVault().ifPresent(VaultHook::hook);
+        Optional<VaultHook> vault = getPlugin().getVault();
+        if (vault.isPresent()) {
+            vault.get().hook();
+        } else {
+            getPlugin().getHooks().registerHook(new VaultHook());
+        }
     }
 
     /**

--- a/src/main/java/com/wasteofplastic/invswitcher/InvSwitcherPladdon.java
+++ b/src/main/java/com/wasteofplastic/invswitcher/InvSwitcherPladdon.java
@@ -2,7 +2,6 @@ package com.wasteofplastic.invswitcher;
 
 
 import world.bentobox.bentobox.api.addons.Addon;
-import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.addons.Pladdon;
 
 public class InvSwitcherPladdon extends Pladdon {

--- a/src/main/java/com/wasteofplastic/invswitcher/Store.java
+++ b/src/main/java/com/wasteofplastic/invswitcher/Store.java
@@ -261,12 +261,10 @@ public class Store {
         // Backward compat: if island-specific key has no data, migrate from world-only key.
         // This only happens once — the world-only data is cleared after migration so that
         // other islands don't also inherit a duplicate copy.
-        if (islandKey.contains("/") && !store.isInventory(islandKey)) {
-            if (store.isInventory(worldKey)) {
-                islandLoadKey = worldKey;
-                // Clear the world-only data so it can't be claimed by another island
-                store.clearWorldData(worldKey);
-            }
+        if (islandKey.contains("/") && !store.isInventory(islandKey) && store.isInventory(worldKey)) {
+            islandLoadKey = worldKey;
+            // Clear the world-only data so it can't be claimed by another island
+            store.clearWorldData(worldKey);
         }
 
         // Each option uses the island key or the world key based on its island sub-setting
@@ -549,11 +547,8 @@ public class Store {
         case BLOCK -> store.getBlockStats(worldName).getOrDefault(s, Collections.emptyMap()).forEach((k,v) -> player.setStatistic(s, k, v));
         case ITEM -> store.getItemStats(worldName).getOrDefault(s, Collections.emptyMap()).forEach((k,v) -> player.setStatistic(s, k, v));
         case ENTITY -> store.getEntityStats(worldName).getOrDefault(s, Collections.emptyMap()).forEach((k,v) -> player.setStatistic(s, k, v));
-        case UNTYPED -> {
-            if (store.getUntypedStats(worldName).containsKey(s)) {
-                player.setStatistic(s, store.getUntypedStats(worldName).get(s));
-            }
-        }
+        case UNTYPED -> Optional.ofNullable(store.getUntypedStats(worldName).get(s))
+                .ifPresent(v -> player.setStatistic(s, v));
         }
     }
 

--- a/src/main/java/com/wasteofplastic/invswitcher/Store.java
+++ b/src/main/java/com/wasteofplastic/invswitcher/Store.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
@@ -71,6 +72,19 @@ public class Store {
     private final Map<UUID, InventoryStorage> cache;
     private final Map<UUID, String> currentKey;
     private final InvSwitcher addon;
+    /**
+     * Offline storage objects whose asynchronous save has not yet flushed to the database, kept so
+     * that a follow-up read or write reuses the same in-memory copy instead of reloading a stale one.
+     * Without this, two rapid sequential economy transactions on an offline player would each load
+     * an independent copy from the database before the first save landed, losing the first update.
+     * Entries are dropped once all their in-flight saves complete (see {@link #pendingSaveCount}), so
+     * a later login still reloads fresh data. Economy operations run on the main thread, so this map
+     * stays small and self-clearing.
+     */
+    private final Map<UUID, InventoryStorage> pendingSaves = new ConcurrentHashMap<>();
+    /** Number of in-flight saves per offline player, so a pending object is only evicted once the
+     *  last of its saves has flushed. Mutated only on the main thread (see {@link #saveStorage}). */
+    private final Map<UUID, Integer> pendingSaveCount = new ConcurrentHashMap<>();
 
     public Store(InvSwitcher addon) {
         this.addon = addon;
@@ -845,6 +859,13 @@ public class Store {
         if (cache.containsKey(uuid)) {
             return cache.get(uuid);
         }
+        // An offline write may still be in flight (not yet flushed to the database). Reuse that same
+        // object so this read - and any follow-up write built on it - sees the pending change rather
+        // than a stale reload. This is what keeps rapid sequential offline transactions consistent.
+        InventoryStorage pending = pendingSaves.get(uuid);
+        if (pending != null) {
+            return pending;
+        }
         if (database.objectExists(uuid.toString())) {
             InventoryStorage store = database.loadObject(uuid.toString());
             if (store != null) {
@@ -858,10 +879,43 @@ public class Store {
 
     /**
      * Persist a storage object asynchronously.
+     * <p>
+     * For an online (cached) player the cache is the source of truth, so a plain async save cannot
+     * be read back stale. For an offline player the object is transient and not cached, so the save
+     * is tracked in {@link #pendingSaves} until it flushes - otherwise a follow-up read would reload
+     * a stale copy from the database before the async write landed, losing the update.
      * @param store - storage to save
      */
     public void saveStorage(InventoryStorage store) {
-        database.saveObjectAsync(store);
+        UUID uuid = UUID.fromString(store.getUniqueId());
+        if (cache.containsKey(uuid)) {
+            database.saveObjectAsync(store);
+            return;
+        }
+        pendingSaves.put(uuid, store);
+        pendingSaveCount.merge(uuid, 1, Integer::sum);
+        database.saveObjectAsync(store).whenComplete((r, ex) -> onOfflineSaveComplete(uuid));
+    }
+
+    /**
+     * Drop a pending offline save once it has flushed, but only when it was the last save in flight
+     * for that player, so a still-pending later write keeps its object available. Runs the eviction
+     * on the main thread to stay consistent with {@link #saveStorage}; during shutdown the scheduler
+     * is unavailable, so it evicts inline.
+     * @param uuid - the player whose save completed
+     */
+    private void onOfflineSaveComplete(UUID uuid) {
+        Runnable evict = () -> {
+            if (pendingSaveCount.merge(uuid, -1, Integer::sum) <= 0) {
+                pendingSaveCount.remove(uuid);
+                pendingSaves.remove(uuid);
+            }
+        };
+        if (addon.getPlugin().isEnabled()) {
+            Bukkit.getScheduler().runTask(addon.getPlugin(), evict);
+        } else {
+            evict.run();
+        }
     }
 
     /**

--- a/src/main/java/com/wasteofplastic/invswitcher/commands/admin/AbstractAdminAmountCommand.java
+++ b/src/main/java/com/wasteofplastic/invswitcher/commands/admin/AbstractAdminAmountCommand.java
@@ -62,7 +62,10 @@ public abstract class AbstractAdminAmountCommand extends AbstractAdminMoneyComma
             user.sendMessage("invswitcher.errors.insufficient-funds");
             return false;
         }
-        sendBalanceMessage(user, successKey(), target, world);
+        // Report the balance returned by the transaction itself. Re-reading here would reload an
+        // offline target fresh from the database before the asynchronous save has flushed, showing
+        // the stale pre-transaction balance.
+        sendBalanceMessage(user, successKey(), target, response.balance);
         return true;
     }
 }

--- a/src/main/java/com/wasteofplastic/invswitcher/commands/admin/AbstractAdminMoneyCommand.java
+++ b/src/main/java/com/wasteofplastic/invswitcher/commands/admin/AbstractAdminMoneyCommand.java
@@ -38,14 +38,31 @@ public abstract class AbstractAdminMoneyCommand extends AbstractMoneyCommand {
 
     /**
      * Send a message reporting the target's balance for the given world, with [name] and [number].
+     * Reads the balance from the economy, so only use this when no write is in flight (a write's
+     * asynchronous save may not have flushed yet, making a fresh read of an offline player stale).
+     * After a transaction, prefer {@link #sendBalanceMessage(User, String, User, double)} with the
+     * balance from the {@code EconomyResponse}.
      * @param user - command sender
      * @param messageKey - locale key of the message
      * @param target - the target player
      * @param world - the world to report the balance for
      */
     protected void sendBalanceMessage(User user, String messageKey, User target, String world) {
+        sendBalanceMessage(user, messageKey, target, economy().getBalance(target.getOfflinePlayer(), world));
+    }
+
+    /**
+     * Send a message reporting a known balance, with [name] and [number]. Use this after a
+     * transaction with the balance returned in the {@link net.milkbowl.vault.economy.EconomyResponse},
+     * which is authoritative and avoids re-reading an offline player before the async save has flushed.
+     * @param user - command sender
+     * @param messageKey - locale key of the message
+     * @param target - the target player
+     * @param balance - the balance to report
+     */
+    protected void sendBalanceMessage(User user, String messageKey, User target, double balance) {
         user.sendMessage(messageKey, TextVariables.NAME, target.getName(),
-                TextVariables.NUMBER, economy().format(economy().getBalance(target.getOfflinePlayer(), world)));
+                TextVariables.NUMBER, economy().format(balance));
     }
 
     /**

--- a/src/main/java/com/wasteofplastic/invswitcher/economy/InvEconomy.java
+++ b/src/main/java/com/wasteofplastic/invswitcher/economy/InvEconomy.java
@@ -28,12 +28,21 @@ import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
  *
  * @author tastybento
  */
+// The name-based account methods below implement Vault's deprecated Economy interface methods and
+// must call Bukkit.getOfflinePlayer(String); both are out of our control, so suppress the warnings.
+@SuppressWarnings({ "deprecation", "removal" })
 public class InvEconomy implements Economy {
 
     private static final String NEGATIVE_DEPOSIT = "Cannot deposit a negative amount";
     private static final String NEGATIVE_WITHDRAW = "Cannot withdraw a negative amount";
     private static final String NEGATIVE_SET = "Cannot set a negative balance";
     private static final String INSUFFICIENT_FUNDS = "Insufficient funds";
+    // Debug message fragments, factored out to avoid duplicated string literals.
+    private static final String DBG_KEY = " key=";
+    private static final String DBG_AMOUNT = " amount=";
+    private static final String ROUTE_SELF = " -> self";
+    private static final String ROUTE_DELEGATE = " -> DELEGATE";
+    private static final String ROUTE_DEFAULT = " -> default";
 
     private final InvSwitcher addon;
     /** The economy to fall back to for unmanaged worlds (e.g. EssentialsX). Resolved lazily on
@@ -118,6 +127,21 @@ public class InvEconomy implements Economy {
         if (settings().isEconomyDebug()) {
             addon.log("[economy] " + msg);
         }
+    }
+
+    /**
+     * Debug-only suffix describing where a balance call routed: to the player's own managed balance
+     * ({@code managedSuffix}), or - when the world is unmanaged - to the delegate economy or the
+     * default key.
+     * @param key - the resolved money key, or null if the world is unmanaged
+     * @param managedSuffix - suffix to use when the key is non-null (managed)
+     * @return the routing suffix for the debug message
+     */
+    private String routeSuffix(String key, String managedSuffix) {
+        if (key != null) {
+            return managedSuffix;
+        }
+        return delegating() ? ROUTE_DELEGATE : ROUTE_DEFAULT;
     }
 
     private static String who(OfflinePlayer player) {
@@ -260,7 +284,7 @@ public class InvEconomy implements Economy {
     @Override
     public double getBalance(OfflinePlayer player) {
         String key = currentKey(player);
-        debug("getBalance " + who(player) + " key=" + key + (key == null ? (delegating() ? " -> DELEGATE" : " -> default") : ""));
+        debug("getBalance " + who(player) + DBG_KEY + key + routeSuffix(key, ""));
         if (key == null) {
             return delegating() ? delegate().getBalance(player) : readSelf(player, Store.DEFAULT_WORLD_KEY);
         }
@@ -289,8 +313,7 @@ public class InvEconomy implements Economy {
     @Override
     public EconomyResponse withdrawPlayer(OfflinePlayer player, double amount) {
         String key = currentKey(player);
-        debug("withdrawPlayer " + who(player) + " amount=" + amount + " key=" + key
-                + (key == null ? (delegating() ? " -> DELEGATE" : " -> default") : " -> self"));
+        debug("withdrawPlayer " + who(player) + DBG_AMOUNT + amount + DBG_KEY + key + routeSuffix(key, ROUTE_SELF));
         if (key == null) {
             return delegating() ? delegate().withdrawPlayer(player, amount)
                     : withdrawSelf(player, Store.DEFAULT_WORLD_KEY, amount);
@@ -301,8 +324,8 @@ public class InvEconomy implements Economy {
     @Override
     public EconomyResponse withdrawPlayer(OfflinePlayer player, String worldName, double amount) {
         String key = worldKey(player, worldName);
-        debug("withdrawPlayer(world) " + who(player) + " world=" + worldName + " amount=" + amount + " key=" + key
-                + (key == null ? (delegating() ? " -> DELEGATE" : " -> default") : " -> self"));
+        debug("withdrawPlayer(world) " + who(player) + " world=" + worldName + DBG_AMOUNT + amount + DBG_KEY + key
+                + routeSuffix(key, ROUTE_SELF));
         if (key == null) {
             return delegating() ? delegate().withdrawPlayer(player, worldName, amount)
                     : withdrawSelf(player, Store.DEFAULT_WORLD_KEY, amount);
@@ -313,8 +336,7 @@ public class InvEconomy implements Economy {
     @Override
     public EconomyResponse depositPlayer(OfflinePlayer player, double amount) {
         String key = currentKey(player);
-        debug("depositPlayer " + who(player) + " amount=" + amount + " key=" + key
-                + (key == null ? (delegating() ? " -> DELEGATE" : " -> default") : " -> self"));
+        debug("depositPlayer " + who(player) + DBG_AMOUNT + amount + DBG_KEY + key + routeSuffix(key, ROUTE_SELF));
         if (key == null) {
             return delegating() ? delegate().depositPlayer(player, amount)
                     : depositSelf(player, Store.DEFAULT_WORLD_KEY, amount);
@@ -325,8 +347,8 @@ public class InvEconomy implements Economy {
     @Override
     public EconomyResponse depositPlayer(OfflinePlayer player, String worldName, double amount) {
         String key = worldKey(player, worldName);
-        debug("depositPlayer(world) " + who(player) + " world=" + worldName + " amount=" + amount + " key=" + key
-                + (key == null ? (delegating() ? " -> DELEGATE" : " -> default") : " -> self"));
+        debug("depositPlayer(world) " + who(player) + " world=" + worldName + DBG_AMOUNT + amount + DBG_KEY + key
+                + routeSuffix(key, ROUTE_SELF));
         if (key == null) {
             return delegating() ? delegate().depositPlayer(player, worldName, amount)
                     : depositSelf(player, Store.DEFAULT_WORLD_KEY, amount);
@@ -389,73 +411,61 @@ public class InvEconomy implements Economy {
     // ------ DEPRECATED NAME-BASED METHODS (delegate up to OfflinePlayer variants) ------
 
     @Override
-    @Deprecated
     public boolean hasAccount(String playerName) {
         return hasAccount(Bukkit.getOfflinePlayer(playerName));
     }
 
     @Override
-    @Deprecated
     public boolean hasAccount(String playerName, String worldName) {
         return hasAccount(Bukkit.getOfflinePlayer(playerName), worldName);
     }
 
     @Override
-    @Deprecated
     public double getBalance(String playerName) {
         return getBalance(Bukkit.getOfflinePlayer(playerName));
     }
 
     @Override
-    @Deprecated
     public double getBalance(String playerName, String world) {
         return getBalance(Bukkit.getOfflinePlayer(playerName), world);
     }
 
     @Override
-    @Deprecated
     public boolean has(String playerName, double amount) {
         return has(Bukkit.getOfflinePlayer(playerName), amount);
     }
 
     @Override
-    @Deprecated
     public boolean has(String playerName, String worldName, double amount) {
         return has(Bukkit.getOfflinePlayer(playerName), worldName, amount);
     }
 
     @Override
-    @Deprecated
     public EconomyResponse withdrawPlayer(String playerName, double amount) {
         return withdrawPlayer(Bukkit.getOfflinePlayer(playerName), amount);
     }
 
     @Override
-    @Deprecated
     public EconomyResponse withdrawPlayer(String playerName, String worldName, double amount) {
         return withdrawPlayer(Bukkit.getOfflinePlayer(playerName), worldName, amount);
     }
 
     @Override
-    @Deprecated
     public EconomyResponse depositPlayer(String playerName, double amount) {
         return depositPlayer(Bukkit.getOfflinePlayer(playerName), amount);
     }
 
     @Override
-    @Deprecated
     public EconomyResponse depositPlayer(String playerName, String worldName, double amount) {
         return depositPlayer(Bukkit.getOfflinePlayer(playerName), worldName, amount);
     }
 
     @Override
-    @Deprecated
     public boolean createPlayerAccount(String playerName) {
         return createPlayerAccount(Bukkit.getOfflinePlayer(playerName));
     }
 
     @Override
-    @Deprecated
     public boolean createPlayerAccount(String playerName, String worldName) {
         return createPlayerAccount(Bukkit.getOfflinePlayer(playerName), worldName);
     }
@@ -472,7 +482,6 @@ public class InvEconomy implements Economy {
     }
 
     @Override
-    @Deprecated
     public EconomyResponse createBank(String name, String player) {
         return delegate() != null ? delegate().createBank(name, player) : bankUnsupported();
     }
@@ -508,7 +517,6 @@ public class InvEconomy implements Economy {
     }
 
     @Override
-    @Deprecated
     public EconomyResponse isBankOwner(String name, String playerName) {
         return delegate() != null ? delegate().isBankOwner(name, playerName) : bankUnsupported();
     }
@@ -519,7 +527,6 @@ public class InvEconomy implements Economy {
     }
 
     @Override
-    @Deprecated
     public EconomyResponse isBankMember(String name, String playerName) {
         return delegate() != null ? delegate().isBankMember(name, playerName) : bankUnsupported();
     }

--- a/src/test/java/com/wasteofplastic/invswitcher/InvSwitcherTest.java
+++ b/src/test/java/com/wasteofplastic/invswitcher/InvSwitcherTest.java
@@ -50,7 +50,6 @@ import world.bentobox.bentobox.api.addons.AddonDescription;
 import world.bentobox.bentobox.database.DatabaseSetup.DatabaseType;
 import world.bentobox.bentobox.managers.AddonsManager;
 import org.mockbukkit.mockbukkit.MockBukkit;
-import org.mockbukkit.mockbukkit.ServerMock;
 
 /**
  * @author tastybento
@@ -58,7 +57,7 @@ import org.mockbukkit.mockbukkit.ServerMock;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class InvSwitcherTest {
+class InvSwitcherTest {
 
     private static File jFile;
     @Mock
@@ -79,7 +78,7 @@ public class InvSwitcherTest {
     private MockedStatic<BentoBox> mockedBentoBox;
 
     @BeforeAll
-    public static void beforeClass() throws IOException {
+    static void beforeClass() throws IOException {
         // Make the addon jar
         jFile = new File("addon.jar");
         // Copy over config file from src folder
@@ -100,12 +99,9 @@ public class InvSwitcherTest {
         }
     }
 
-    /**
-     * @throws Exception
-     */
     @BeforeEach
-    public void setUp() throws Exception {
-        ServerMock server = MockBukkit.mock();
+    void setUp() {
+        MockBukkit.mock();
 
         // Set up plugin
         mockedBentoBox = Mockito.mockStatic(BentoBox.class);
@@ -135,7 +131,7 @@ public class InvSwitcherTest {
      * @throws java.lang.Exception
      */
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (mockedBentoBox != null) {
             mockedBentoBox.close();
         }
@@ -144,7 +140,7 @@ public class InvSwitcherTest {
     }
 
     @AfterAll
-    public static void cleanUp() throws Exception {
+    static void cleanUp() throws Exception {
         deleteAll(new File("database"));
         new File("addon.jar").delete();
         new File("config.yml").delete();
@@ -164,7 +160,7 @@ public class InvSwitcherTest {
      * Test method for {@link com.wasteofplastic.invswitcher.InvSwitcher#onEnable()}.
      */
     @Test
-    public void testOnEnable() {
+    void testOnEnable() {
         addon.onEnable();
         verify(plugin).logError("[InvSwitcher] This addon is incompatible with YAML database. Please use another type, like JSON.");
         assertEquals(State.DISABLED, addon.getState());
@@ -174,7 +170,7 @@ public class InvSwitcherTest {
      * Test method for {@link com.wasteofplastic.invswitcher.InvSwitcher#onDisable()}.
      */
     @Test
-    public void testOnDisable() {
+    void testOnDisable() {
         // Mock the static method
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS)) {
             when(Bukkit.getWorld(anyString())).thenReturn(world);
@@ -192,7 +188,7 @@ public class InvSwitcherTest {
      * Test method for {@link com.wasteofplastic.invswitcher.InvSwitcher#onLoad()}.
      */
     @Test
-    public void testOnLoad() {
+    void testOnLoad() {
         addon.onLoad();
         File file = new File("config.yml");
         assertTrue(file.exists());
@@ -202,7 +198,7 @@ public class InvSwitcherTest {
      * Test method for {@link com.wasteofplastic.invswitcher.InvSwitcher#allLoaded()}.
      */
     @Test
-    public void testAllLoaded() {
+    void testAllLoaded() {
         // Mock the static method
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS)) {
             when(Bukkit.getWorld(anyString())).thenReturn(world);
@@ -221,7 +217,7 @@ public class InvSwitcherTest {
      * Test method for {@link com.wasteofplastic.invswitcher.InvSwitcher#allLoaded()}.
      */
     @Test
-    public void testAllLoadedNoWorlds() {
+    void testAllLoadedNoWorlds() {
         addon.onLoad();
         addon.getSettings().setWorlds(Collections.emptySet());
         addon.allLoaded();
@@ -234,7 +230,7 @@ public class InvSwitcherTest {
      * Test method for {@link com.wasteofplastic.invswitcher.InvSwitcher#getStore()}.
      */
     @Test
-    public void testGetStore() {
+    void testGetStore() {
         assertNull(addon.getStore());
     }
 
@@ -242,7 +238,7 @@ public class InvSwitcherTest {
      * Test method for {@link com.wasteofplastic.invswitcher.InvSwitcher#getSettings()}.
      */
     @Test
-    public void testGetSettings() {
+    void testGetSettings() {
         assertNull(addon.getSettings());
     }
 
@@ -250,7 +246,7 @@ public class InvSwitcherTest {
      * Test method for {@link com.wasteofplastic.invswitcher.InvSwitcher#getWorlds()}.
      */
     @Test
-    public void testGetWorlds() {
+    void testGetWorlds() {
         assertTrue(addon.getWorlds().isEmpty());
     }
 

--- a/src/test/java/com/wasteofplastic/invswitcher/StoreTest.java
+++ b/src/test/java/com/wasteofplastic/invswitcher/StoreTest.java
@@ -54,6 +54,8 @@ import org.mockito.quality.Strictness;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.database.DatabaseSetup.DatabaseType;
+import com.wasteofplastic.invswitcher.dataobjects.InventoryStorage;
+
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
@@ -723,6 +725,32 @@ public class StoreTest {
             s.clearStoredMoneyForWorld(player, world, island);
         }
         assertEquals(0D, s.getStorageObject(playerUUID).getMoney("world"), 0.0001);
+    }
+
+    /**
+     * An offline player's economy write must be visible to an immediately following read, even
+     * before the asynchronous save flushes. Regression test for give/set reporting a stale balance
+     * because the follow-up read reloaded the player from the database before the save landed.
+     * Verifies {@link Store#saveStorage} tracks the write and {@link Store#getStorageObject} reuses
+     * the pending object.
+     */
+    @Test
+    public void testOfflineWriteVisibleToImmediateRead() {
+        sets.setMoney(true);
+        // Offline player: never cached, so saveStorage takes the pending-save path and getStorageObject
+        // must return a value consistent with the write that just happened. Keep the post-save eviction
+        // scheduled (a no-op on the mocked scheduler) rather than run inline, so the pending object is
+        // still held when we read it back.
+        BentoBox enabledPlugin = mock(BentoBox.class);
+        when(enabledPlugin.isEnabled()).thenReturn(true);
+        when(addon.getPlugin()).thenReturn(enabledPlugin);
+        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS)) {
+            InventoryStorage obj = s.getStorageObject(playerUUID);
+            obj.setMoney("world", 2000D);
+            s.saveStorage(obj);
+            // The follow-up read must reflect the write, not a stale/empty reload.
+            assertEquals(2000D, s.getStorageObject(playerUUID).getMoney("world"), 0.0001);
+        }
     }
 
     /**

--- a/src/test/java/com/wasteofplastic/invswitcher/StoreTest.java
+++ b/src/test/java/com/wasteofplastic/invswitcher/StoreTest.java
@@ -1,5 +1,6 @@
 package com.wasteofplastic.invswitcher;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -61,7 +62,6 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.util.Util;
 import org.mockbukkit.mockbukkit.MockBukkit;
-import org.mockbukkit.mockbukkit.ServerMock;
 
 /**
  * @author tastybento
@@ -69,7 +69,7 @@ import org.mockbukkit.mockbukkit.ServerMock;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class StoreTest {
+class StoreTest {
 
     @Mock
     private InvSwitcher addon;
@@ -96,8 +96,8 @@ public class StoreTest {
     private MockedStatic<BentoBox> mockedBentoBox;
 
     @BeforeEach
-    public void setUp() throws Exception {
-        ServerMock server = MockBukkit.mock();
+    void setUp() {
+        MockBukkit.mock();
 
         // BentoBox
         BentoBox plugin = mock(BentoBox.class);
@@ -154,7 +154,7 @@ public class StoreTest {
     }
 
     @AfterEach
-    public void tearDown() throws IOException {
+    void tearDown() throws IOException {
         if (mockedBentoBox != null) {
             mockedBentoBox.close();
         }
@@ -174,7 +174,7 @@ public class StoreTest {
      * Test method for {@link com.wasteofplastic.invswitcher.Store#Store(com.wasteofplastic.invswitcher.InvSwitcher)}.
      */
     @Test
-    public void testStore() {
+    void testStore() {
         assertNotNull(s);
     }
 
@@ -182,7 +182,7 @@ public class StoreTest {
      * Test method for {@link com.wasteofplastic.invswitcher.Store#isWorldStored(org.bukkit.entity.Player, org.bukkit.World)}.
      */
     @Test
-    public void testIsWorldStored() {
+    void testIsWorldStored() {
         assertFalse(s.isWorldStored(player, world));
         // Disable statistics to avoid registry issues when Bukkit static mock overrides MockBukkit
         sets.setStatistics(false);
@@ -198,7 +198,7 @@ public class StoreTest {
      * Test method for {@link com.wasteofplastic.invswitcher.Store#getInventory(org.bukkit.entity.Player, org.bukkit.World)}.
      */
     @Test
-    public void testGetInventory() {
+    void testGetInventory() {
         s.getInventory(player, world);
         verify(player).setFoodLevel(20);
         verify(player).setHealth(18);
@@ -212,7 +212,7 @@ public class StoreTest {
      * must save and restore XP around the advancement grant step.
      */
     @Test
-    public void testGetInventoryAdvancementsPreservesExperience() {
+    void testGetInventoryAdvancementsPreservesExperience() {
         sets.setAdvancements(true);
         sets.setExperience(true);
         sets.setStatistics(false);
@@ -250,7 +250,7 @@ public class StoreTest {
      * Test method for {@link com.wasteofplastic.invswitcher.Store#removeFromCache(org.bukkit.entity.Player)}.
      */
     @Test
-    public void testRemoveFromCache() {
+    void testRemoveFromCache() {
         s.getInventory(player, world);
         assertNotNull(s.getCurrentKey(player));
         s.removeFromCache(player);
@@ -261,7 +261,7 @@ public class StoreTest {
      * Test method for {@link com.wasteofplastic.invswitcher.Store#storeInventory(org.bukkit.entity.Player, org.bukkit.World)}.
      */
     @Test
-    public void testStoreInventoryNothing() {
+    void testStoreInventoryNothing() {
         // Do not actually save anything
         sets.setAdvancements(false);
         sets.setEnderChest(false);
@@ -302,7 +302,7 @@ public class StoreTest {
      * Test method for {@link com.wasteofplastic.invswitcher.Store#storeInventory(org.bukkit.entity.Player, org.bukkit.World)}.
      */
     @Test
-    public void testStoreInventoryAll() {
+    void testStoreInventoryAll() {
         sets.setAdvancements(true);
         sets.setEnderChest(true);
         sets.setExperience(true);
@@ -340,7 +340,7 @@ public class StoreTest {
      * Test method for {@link com.wasteofplastic.invswitcher.Store#saveOnShutdown()}.
      */
     @Test
-    public void testSaveOnlinePlayers() {
+    void testSaveOnlinePlayers() {
         // Mock the static method
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class)) {
             // Run the code under test
@@ -354,14 +354,14 @@ public class StoreTest {
     // --- Per-island storage key tests ---
 
     @Test
-    public void testGetStorageKeyIslandsDisabled() {
+    void testGetStorageKeyIslandsDisabled() {
         sets.setIslandsActive(false);
         String key = s.getStorageKey(player, world);
         assertEquals("world", key); // nether suffix stripped
     }
 
     @Test
-    public void testGetStorageKeySingleIsland() {
+    void testGetStorageKeySingleIsland() {
         sets.setIslandsActive(true);
         try (MockedStatic<Util> utilities = Mockito.mockStatic(Util.class)) {
             utilities.when(() -> Util.getWorld(world)).thenReturn(world);
@@ -372,7 +372,7 @@ public class StoreTest {
     }
 
     @Test
-    public void testGetStorageKeyMultipleIslandsOnOwnIsland() {
+    void testGetStorageKeyMultipleIslandsOnOwnIsland() {
         sets.setIslandsActive(true);
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(playerUUID);
@@ -391,7 +391,7 @@ public class StoreTest {
     }
 
     @Test
-    public void testGetStorageKeyMultipleIslandsOnOtherPlayerIsland() {
+    void testGetStorageKeyMultipleIslandsOnOtherPlayerIsland() {
         sets.setIslandsActive(true);
         Island island = mock(Island.class);
         UUID otherPlayer = UUID.randomUUID();
@@ -411,7 +411,7 @@ public class StoreTest {
     }
 
     @Test
-    public void testGetStorageKeyWithSpecificIsland() {
+    void testGetStorageKeyWithSpecificIsland() {
         sets.setIslandsActive(true);
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(playerUUID);
@@ -427,7 +427,7 @@ public class StoreTest {
     }
 
     @Test
-    public void testGetStorageKeyGenericNether() {
+    void testGetStorageKeyGenericNether() {
         sets.setIslandsActive(true);
         // Set up a nether world
         World netherWorld = mock(World.class);
@@ -457,19 +457,19 @@ public class StoreTest {
     }
 
     @Test
-    public void testGetCurrentKeyNullByDefault() {
+    void testGetCurrentKeyNullByDefault() {
         assertNull(s.getCurrentKey(player));
     }
 
     @Test
-    public void testGetCurrentKeySetAfterGetInventory() {
+    void testGetCurrentKeySetAfterGetInventory() {
         sets.setIslandsActive(false);
         s.getInventory(player, world);
         assertEquals("world", s.getCurrentKey(player));
     }
 
     @Test
-    public void testRemoveFromCacheClearsCurrentKey() {
+    void testRemoveFromCacheClearsCurrentKey() {
         sets.setIslandsActive(false);
         s.getInventory(player, world);
         assertNotNull(s.getCurrentKey(player));
@@ -481,7 +481,7 @@ public class StoreTest {
      * Test upgradeWorldKeyToIsland clears world data and updates currentKey.
      */
     @Test
-    public void testUpgradeWorldKeyToIsland() {
+    void testUpgradeWorldKeyToIsland() {
         sets.setIslandsActive(true);
         sets.setStatistics(false);
 
@@ -515,7 +515,7 @@ public class StoreTest {
      * Simulates what onIslandEnter does: upgradeWorldKey, storeInventory, getInventory.
      */
     @Test
-    public void testFullScenarioSingleToMultipleIslands() {
+    void testFullScenarioSingleToMultipleIslands() {
         sets.setIslandsActive(true);
         sets.setStatistics(false);
         sets.setHealth(false);
@@ -571,7 +571,7 @@ public class StoreTest {
     // --- Non-BentoBox world tests ---
 
     @Test
-    public void testGetStorageKeyNonBentoBoxWorld() {
+    void testGetStorageKeyNonBentoBoxWorld() {
         World otherWorld = mock(World.class);
         when(otherWorld.getName()).thenReturn("em_adventurers_guild");
         // otherWorld is NOT in bentoboxWorlds
@@ -580,7 +580,7 @@ public class StoreTest {
     }
 
     @Test
-    public void testAllNonBentoBoxWorldsShareKey() {
+    void testAllNonBentoBoxWorldsShareKey() {
         World world1 = mock(World.class);
         when(world1.getName()).thenReturn("world");
         World world2 = mock(World.class);
@@ -594,7 +594,7 @@ public class StoreTest {
     }
 
     @Test
-    public void testBentoBoxToNonBentoBoxRestoresInventory() {
+    void testBentoBoxToNonBentoBoxRestoresInventory() {
         sets.setStatistics(false);
         sets.setAdvancements(false);
 
@@ -619,7 +619,7 @@ public class StoreTest {
     }
 
     @Test
-    public void testMigrationFromOldWorldKey() {
+    void testMigrationFromOldWorldKey() {
         sets.setStatistics(false);
         sets.setAdvancements(false);
 
@@ -655,7 +655,7 @@ public class StoreTest {
      * After clearing, loading inventory for that world should give empty contents.
      */
     @Test
-    public void testClearStoredInventoryForWorld() {
+    void testClearStoredInventoryForWorld() {
         sets.setStatistics(false);
         sets.setAdvancements(false);
         Island island = mock(Island.class);
@@ -681,14 +681,13 @@ public class StoreTest {
      * When ender chest is enabled, clearStoredEnderChestForWorld should work without error.
      */
     @Test
-    public void testClearStoredEnderChestForWorld() {
+    void testClearStoredEnderChestForWorld() {
         sets.setStatistics(false);
         sets.setAdvancements(false);
         Island island = mock(Island.class);
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS)) {
             s.storeInventory(player, world);
-            // Should not throw
-            s.clearStoredEnderChestForWorld(player, world, island);
+            assertDoesNotThrow(() -> s.clearStoredEnderChestForWorld(player, world, island));
         }
     }
 
@@ -696,15 +695,14 @@ public class StoreTest {
      * When experience is enabled, clearStoredExpForWorld should zero out the stored exp.
      */
     @Test
-    public void testClearStoredExpForWorld() {
+    void testClearStoredExpForWorld() {
         sets.setStatistics(false);
         sets.setAdvancements(false);
         Island island = mock(Island.class);
         when(player.getTotalExperience()).thenReturn(500);
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS)) {
             s.storeInventory(player, world);
-            // Should not throw
-            s.clearStoredExpForWorld(player, world, island);
+            assertDoesNotThrow(() -> s.clearStoredExpForWorld(player, world, island));
         }
     }
 
@@ -712,7 +710,7 @@ public class StoreTest {
      * When money is enabled, clearStoredMoneyForWorld should zero the stored balance for the world.
      */
     @Test
-    public void testClearStoredMoneyForWorld() {
+    void testClearStoredMoneyForWorld() {
         sets.setStatistics(false);
         sets.setAdvancements(false);
         sets.setMoney(true);
@@ -735,7 +733,7 @@ public class StoreTest {
      * the pending object.
      */
     @Test
-    public void testOfflineWriteVisibleToImmediateRead() {
+    void testOfflineWriteVisibleToImmediateRead() {
         sets.setMoney(true);
         // Offline player: never cached, so saveStorage takes the pending-save path and getStorageObject
         // must return a value consistent with the write that just happened. Keep the post-save eviction
@@ -757,7 +755,7 @@ public class StoreTest {
      * clearStoredMoneyForWorld should be a no-op when money is disabled in settings.
      */
     @Test
-    public void testClearStoredMoneyForWorldMoneyDisabled() {
+    void testClearStoredMoneyForWorldMoneyDisabled() {
         sets.setStatistics(false);
         sets.setAdvancements(false);
         sets.setMoney(false);
@@ -775,15 +773,14 @@ public class StoreTest {
      * When health is enabled, clearStoredHealthForWorld should work without error.
      */
     @Test
-    public void testClearStoredHealthForWorld() {
+    void testClearStoredHealthForWorld() {
         sets.setStatistics(false);
         sets.setAdvancements(false);
         Island island = mock(Island.class);
         when(player.getHealth()).thenReturn(10.0);
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS)) {
             s.storeInventory(player, world);
-            // Should not throw
-            s.clearStoredHealthForWorld(player, world, island);
+            assertDoesNotThrow(() -> s.clearStoredHealthForWorld(player, world, island));
         }
     }
 
@@ -791,15 +788,14 @@ public class StoreTest {
      * When food is enabled, clearStoredFoodForWorld should work without error.
      */
     @Test
-    public void testClearStoredFoodForWorld() {
+    void testClearStoredFoodForWorld() {
         sets.setStatistics(false);
         sets.setAdvancements(false);
         Island island = mock(Island.class);
         when(player.getFoodLevel()).thenReturn(8);
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS)) {
             s.storeInventory(player, world);
-            // Should not throw
-            s.clearStoredFoodForWorld(player, world, island);
+            assertDoesNotThrow(() -> s.clearStoredFoodForWorld(player, world, island));
         }
     }
 
@@ -808,7 +804,7 @@ public class StoreTest {
      * No exceptions should be thrown.
      */
     @Test
-    public void testClearStoredInventoryForWorldInventoryDisabled() {
+    void testClearStoredInventoryForWorldInventoryDisabled() {
         sets.setInventory(false);
         sets.setStatistics(false);
         sets.setAdvancements(false);
@@ -828,7 +824,7 @@ public class StoreTest {
      * getStorageKeyForEvent should return the world name when islands mode is inactive.
      */
     @Test
-    public void testGetStorageKeyForEventIslandsDisabled() {
+    void testGetStorageKeyForEventIslandsDisabled() {
         sets.setIslandsActive(false);
         Island island = mock(Island.class);
         String key = s.getStorageKeyForEvent(player, world, island);
@@ -839,7 +835,7 @@ public class StoreTest {
      * getStorageKeyForEvent should return world name when player has only 1 island.
      */
     @Test
-    public void testGetStorageKeyForEventSingleIsland() {
+    void testGetStorageKeyForEventSingleIsland() {
         sets.setIslandsActive(true);
         Island island = mock(Island.class);
         try (MockedStatic<Util> mockedUtil = mockStatic(Util.class)) {
@@ -855,7 +851,7 @@ public class StoreTest {
      * and has multiple islands.
      */
     @Test
-    public void testGetStorageKeyForEventMultipleIslandsOwner() {
+    void testGetStorageKeyForEventMultipleIslandsOwner() {
         sets.setIslandsActive(true);
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(playerUUID);
@@ -873,7 +869,7 @@ public class StoreTest {
      * (e.g., kicked from a team). Uses the world-level key since the player is a member, not owner.
      */
     @Test
-    public void testGetStorageKeyForEventMultipleIslandsNotOwner() {
+    void testGetStorageKeyForEventMultipleIslandsNotOwner() {
         sets.setIslandsActive(true);
         Island island = mock(Island.class);
         UUID otherOwner = UUID.randomUUID();

--- a/src/test/java/com/wasteofplastic/invswitcher/dataobjects/InventoryStorageTest.java
+++ b/src/test/java/com/wasteofplastic/invswitcher/dataobjects/InventoryStorageTest.java
@@ -28,7 +28,7 @@ import org.mockbukkit.mockbukkit.MockBukkit;
  *
  */
 @ExtendWith(MockitoExtension.class)
-public class InventoryStorageTest {
+class InventoryStorageTest {
 
 
     private InventoryStorage is;
@@ -36,13 +36,13 @@ public class InventoryStorageTest {
     /**
      */
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         MockBukkit.mock();
         is = new InventoryStorage();
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         MockBukkit.unmock();
     }
 
@@ -50,7 +50,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getUniqueId()}.
      */
     @Test
-    public void testGetUniqueId() {
+    void testGetUniqueId() {
         assertNull(is.getUniqueId());
     }
 
@@ -58,7 +58,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setUniqueId(java.lang.String)}.
      */
     @Test
-    public void testSetUniqueId() {
+    void testSetUniqueId() {
         String uuid = UUID.randomUUID().toString();
         is.setUniqueId(uuid);
         assertEquals(uuid, is.getUniqueId());
@@ -68,7 +68,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getInventory()}.
      */
     @Test
-    public void testGetInventory() {
+    void testGetInventory() {
         assertTrue(is.getInventory().isEmpty());
     }
 
@@ -76,7 +76,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getHealth()}.
      */
     @Test
-    public void testGetHealth() {
+    void testGetHealth() {
         assertTrue(is.getHealth().isEmpty());
     }
 
@@ -84,7 +84,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getFood()}.
      */
     @Test
-    public void testGetFood() {
+    void testGetFood() {
         assertTrue(is.getFood().isEmpty());
     }
 
@@ -92,7 +92,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getExp()}.
      */
     @Test
-    public void testGetExp() {
+    void testGetExp() {
         assertTrue(is.getExp().isEmpty());
     }
 
@@ -100,7 +100,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getLocation()}.
      */
     @Test
-    public void testGetLocation() {
+    void testGetLocation() {
         assertTrue(is.getLocation().isEmpty());
     }
 
@@ -108,7 +108,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setInventory(java.util.Map)}.
      */
     @Test
-    public void testSetInventoryMapOfStringListOfItemStack() {
+    void testSetInventoryMapOfStringListOfItemStack() {
         ItemStack item = new ItemStack(Material.ACACIA_BOAT);
         is.setInventory(Map.of("test", List.of(item)));
         Map<String, List<ItemStack>> map = is.getInventory();
@@ -119,7 +119,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setInventory(java.lang.String, java.util.List)}.
      */
     @Test
-    public void testSetInventoryStringListOfItemStack() {
+    void testSetInventoryStringListOfItemStack() {
         ItemStack item = new ItemStack(Material.ACACIA_BOAT);
         is.setInventory("worldName", List.of(item));
         Map<String, List<ItemStack>> map = is.getInventory();
@@ -130,7 +130,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setHealth(java.util.Map)}.
      */
     @Test
-    public void testSetHealthMapOfStringDouble() {
+    void testSetHealthMapOfStringDouble() {
         Map<String, Double> map = Map.of("test", 234D);
         is.setHealth(map);
         assertEquals(234D, is.getHealth().get("test"), 0D);
@@ -140,7 +140,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setFood(java.util.Map)}.
      */
     @Test
-    public void testSetFoodMapOfStringInteger() {
+    void testSetFoodMapOfStringInteger() {
         Map<String, Integer> map = Map.of("test", 234);
         is.setFood(map);
         assertEquals(234, is.getFood().get("test").intValue());
@@ -150,7 +150,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setExp(java.util.Map)}.
      */
     @Test
-    public void testSetExpMapOfStringInteger() {
+    void testSetExpMapOfStringInteger() {
         Map<String, Integer> map = Map.of("test", 234);
         is.setExp(map);
         assertEquals(234, is.getExp().get("test").intValue());
@@ -160,7 +160,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setLocation(java.util.Map)}.
      */
     @Test
-    public void testSetLocationMapOfStringLocation() {
+    void testSetLocationMapOfStringLocation() {
         Location loc = mock(Location.class);
         Map<String, Location> map = Map.of("test", loc);
         is.setLocation(map);
@@ -171,7 +171,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setHealth(java.lang.String, double)}.
      */
     @Test
-    public void testSetHealthStringDouble() {
+    void testSetHealthStringDouble() {
         is.setHealth("test", 10D);
         assertEquals(10D, is.getHealth().get("test"), 0D);
     }
@@ -180,7 +180,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setFood(java.lang.String, int)}.
      */
     @Test
-    public void testSetFoodStringInt() {
+    void testSetFoodStringInt() {
         is.setFood("test", 234);
         assertEquals(234, is.getFood().get("test").intValue());
     }
@@ -189,7 +189,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setExp(java.lang.String, int)}.
      */
     @Test
-    public void testSetExpStringInt() {
+    void testSetExpStringInt() {
         is.setExp("test", 234);
         assertEquals(234, is.getExp().get("test").intValue());
     }
@@ -198,7 +198,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setLocation(java.lang.String, org.bukkit.Location)}.
      */
     @Test
-    public void testSetLocationStringLocation() {
+    void testSetLocationStringLocation() {
         Location loc = mock(Location.class);
         is.setLocation("test", loc);
         assertEquals(loc, is.getLocation().get("test"));
@@ -208,7 +208,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getInventory(java.lang.String)}.
      */
     @Test
-    public void testGetInventoryString() {
+    void testGetInventoryString() {
         assertTrue(is.getInventory("test").isEmpty());
     }
 
@@ -216,7 +216,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#isInventory(java.lang.String)}.
      */
     @Test
-    public void testIsInventory() {
+    void testIsInventory() {
         assertFalse(is.isInventory("test"));
     }
 
@@ -224,7 +224,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setGameMode(java.lang.String, org.bukkit.GameMode)}.
      */
     @Test
-    public void testSetGameMode() {
+    void testSetGameMode() {
         is.setGameMode("test", GameMode.ADVENTURE);
         assertEquals(GameMode.ADVENTURE, is.getGameMode("test"));
     }
@@ -233,7 +233,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getGameMode(java.lang.String)}.
      */
     @Test
-    public void testGetGameMode() {
+    void testGetGameMode() {
         is.setGameMode("test2", GameMode.ADVENTURE);
         assertEquals(GameMode.SURVIVAL, is.getGameMode("test"));
         assertEquals(GameMode.ADVENTURE, is.getGameMode("test2"));
@@ -243,7 +243,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setAdvancement(java.lang.String, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testSetAdvancement() {
+    void testSetAdvancement() {
         is.setAdvancement("word", "key", List.of("criteria", "cirt"));
         assertTrue(is.getAdvancements("test").isEmpty());
         Map<String, List<String>> r = is.getAdvancements("word");
@@ -254,7 +254,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#clearAdvancement(java.lang.String)}.
      */
     @Test
-    public void testClearAdvancement() {
+    void testClearAdvancement() {
         is.setAdvancement("word", "key", List.of("criteria", "cirt"));
         assertFalse(is.getAdvancements("word").isEmpty());
         is.clearAdvancement("wowoow");
@@ -267,7 +267,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getAdvancements(java.lang.String)}.
      */
     @Test
-    public void testGetAdvancements() {
+    void testGetAdvancements() {
         assertTrue(is.getAdvancements("test").isEmpty());
     }
 
@@ -275,7 +275,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getEnderChest(java.lang.String)}.
      */
     @Test
-    public void testGetEnderChestString() {
+    void testGetEnderChestString() {
         assertTrue(is.getEnderChest("test").isEmpty());
     }
 
@@ -283,7 +283,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setEnderChest(java.lang.String, java.util.List)}.
      */
     @Test
-    public void testSetEnderChestStringListOfItemStack() {
+    void testSetEnderChestStringListOfItemStack() {
         ItemStack item = new ItemStack(Material.ACACIA_BOAT);
         is.setEnderChest("worldName", List.of(item));
         Map<String, List<ItemStack>> map = is.getEnderChest();
@@ -294,7 +294,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getEnderChest()}.
      */
     @Test
-    public void testGetEnderChest() {
+    void testGetEnderChest() {
         assertTrue(is.getEnderChest().isEmpty());
     }
 
@@ -302,7 +302,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setEnderChest(java.util.Map)}.
      */
     @Test
-    public void testSetEnderChestMapOfStringListOfItemStack() {
+    void testSetEnderChestMapOfStringListOfItemStack() {
         ItemStack item = new ItemStack(Material.ACACIA_BOAT);
         Map<String, List<ItemStack>> map = Map.of("worldName", List.of(item));
         is.setEnderChest(map);
@@ -314,7 +314,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#clearStats(java.lang.String)}.
      */
     @Test
-    public void testClearStats() {
+    void testClearStats() {
         is.setBlockStats("test", Map.of(Statistic.MINE_BLOCK, Map.of(Material.STONE, 3000)));
         is.setEntityStats("test", Map.of(Statistic.ENTITY_KILLED_BY, Map.of(EntityType.BEE, 4000)));
         is.setItemStats("test", Map.of(Statistic.USE_ITEM, Map.of(Material.DIAMOND_AXE, 5000)));
@@ -335,7 +335,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getUntypedStats(java.lang.String)}.
      */
     @Test
-    public void testGetUntypedStats() {
+    void testGetUntypedStats() {
         assertTrue(is.getUntypedStats("test").isEmpty());
     }
 
@@ -343,7 +343,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#setUntypedStats(java.lang.String, java.util.Map)}.
      */
     @Test
-    public void testSetUntypedStats() {
+    void testSetUntypedStats() {
         assertTrue(is.getUntypedStats("test").isEmpty());
         is.setUntypedStats("test", Map.of(Statistic.ARMOR_CLEANED, 30));
         assertEquals(30, is.getUntypedStats("test").get(Statistic.ARMOR_CLEANED).intValue());
@@ -353,7 +353,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getBlockStats(java.lang.String)}.
      */
     @Test
-    public void testGetBlockStats() {
+    void testGetBlockStats() {
         assertTrue(is.getBlockStats("test").isEmpty());
         is.setBlockStats("test", Map.of(Statistic.MINE_BLOCK, Map.of(Material.STONE, 3000)));
         assertEquals(3000, is.getBlockStats("test").get(Statistic.MINE_BLOCK).get(Material.STONE).intValue());
@@ -364,7 +364,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getItemStats(java.lang.String)}.
      */
     @Test
-    public void testGetItemStats() {
+    void testGetItemStats() {
         assertTrue(is.getItemStats("test").isEmpty());
         is.setItemStats("test", Map.of(Statistic.MINE_BLOCK, Map.of(Material.STONE, 3000)));
         assertEquals(3000, is.getItemStats("test").get(Statistic.MINE_BLOCK).get(Material.STONE).intValue());
@@ -374,7 +374,7 @@ public class InventoryStorageTest {
      * Test method for {@link com.wasteofplastic.invswitcher.dataobjects.InventoryStorage#getEntityStats(java.lang.String)}.
      */
     @Test
-    public void testGetEntityStats() {
+    void testGetEntityStats() {
         assertTrue(is.getEntityStats("test").isEmpty());
         is.setEntityStats("test", Map.of(Statistic.MINE_BLOCK, Map.of(EntityType.BLAZE, 3000)));
         assertEquals(3000, is.getEntityStats("test").get(Statistic.MINE_BLOCK).get(EntityType.BLAZE).intValue());
@@ -386,7 +386,7 @@ public class InventoryStorageTest {
      * initializers are bypassed). setMoney must lazily create the map rather than throw.
      */
     @Test
-    public void testSetMoneyWhenMapNull() {
+    void testSetMoneyWhenMapNull() {
         is.setMoney((Map<String, Double>) null);
         is.setMoney("world", 100.0);
         assertEquals(100.0, is.getMoney("world"), 0.0001);
@@ -396,7 +396,7 @@ public class InventoryStorageTest {
      * clearWorldData must not throw when the money map is null.
      */
     @Test
-    public void testClearWorldDataWhenMoneyNull() {
+    void testClearWorldDataWhenMoneyNull() {
         is.setMoney((Map<String, Double>) null);
         is.clearWorldData("world");
         assertNull(is.getMoney("world"));

--- a/src/test/java/com/wasteofplastic/invswitcher/economy/InvEconomyTest.java
+++ b/src/test/java/com/wasteofplastic/invswitcher/economy/InvEconomyTest.java
@@ -41,7 +41,6 @@ import org.mockbukkit.mockbukkit.MockBukkit;
 import com.wasteofplastic.invswitcher.InvSwitcher;
 import com.wasteofplastic.invswitcher.Settings;
 import com.wasteofplastic.invswitcher.Store;
-import com.wasteofplastic.invswitcher.dataobjects.InventoryStorage;
 
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
@@ -56,7 +55,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class InvEconomyTest {
+class InvEconomyTest {
 
     @Mock
     private InvSwitcher addon;
@@ -81,7 +80,7 @@ public class InvEconomyTest {
     private MockedStatic<BentoBox> mockedBentoBox;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         MockBukkit.mock();
 
         BentoBox plugin = mock(BentoBox.class);
@@ -117,7 +116,7 @@ public class InvEconomyTest {
     }
 
     @AfterEach
-    public void tearDown() throws IOException {
+    void tearDown() throws IOException {
         if (mockedBentoBox != null) {
             mockedBentoBox.close();
         }
@@ -129,19 +128,19 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testEnabledAndName() {
+    void testEnabledAndName() {
         assertTrue(economy.isEnabled());
         assertEquals("InvSwitcher", economy.getName());
     }
 
     @Test
-    public void testFormatSingularAndPlural() {
+    void testFormatSingularAndPlural() {
         assertEquals("1.00 Dollar", economy.format(1.0));
         assertEquals("2.50 Dollars", economy.format(2.5));
     }
 
     @Test
-    public void testDepositManagedWorld() {
+    void testDepositManagedWorld() {
         EconomyResponse r = economy.depositPlayer(player, 100.0);
         assertTrue(r.transactionSuccess());
         assertEquals(100.0, economy.getBalance(player), 0.0001);
@@ -152,7 +151,7 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testWithdrawSuccessAndInsufficient() {
+    void testWithdrawSuccessAndInsufficient() {
         economy.depositPlayer(player, 100.0);
         EconomyResponse ok = economy.withdrawPlayer(player, 30.0);
         assertTrue(ok.transactionSuccess());
@@ -164,13 +163,13 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testStartingBalance() {
+    void testStartingBalance() {
         sets.setStartingBalance(50.0);
         assertEquals(50.0, economy.getBalance(player), 0.0001);
     }
 
     @Test
-    public void testImportOnce() {
+    void testImportOnce() {
         sets.setImportExistingBalances(true);
         when(delegate.getBalance(player)).thenReturn(500.0);
 
@@ -184,7 +183,7 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testDelegateUnmanagedWorld() {
+    void testDelegateUnmanagedWorld() {
         World lobby = mock(World.class);
         when(lobby.getName()).thenReturn("lobby");
         when(player.getWorld()).thenReturn(lobby); // not a managed world
@@ -199,7 +198,7 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testSetBalance() {
+    void testSetBalance() {
         economy.depositPlayer(player, 100.0);
         EconomyResponse r = economy.setBalance(player, 42.0);
         assertTrue(r.transactionSuccess());
@@ -207,7 +206,7 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testSetBalanceWorld() {
+    void testSetBalanceWorld() {
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, RETURNS_MOCKS)) {
             mockedBukkit.when(() -> Bukkit.getWorld("world")).thenReturn(world);
             EconomyResponse r = economy.setBalance(player, "world", 42.0);
@@ -217,7 +216,7 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testWorldAwareManagedRouting() {
+    void testWorldAwareManagedRouting() {
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, RETURNS_MOCKS)) {
             mockedBukkit.when(() -> Bukkit.getWorld("world")).thenReturn(world);
             EconomyResponse r = economy.depositPlayer(player, "world", 250.0);
@@ -228,7 +227,7 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testWorldAwareUnmanagedDelegates() {
+    void testWorldAwareUnmanagedDelegates() {
         when(delegate.depositPlayer(player, "lobby", 10.0))
                 .thenReturn(new EconomyResponse(10, 10, ResponseType.SUCCESS, null));
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, RETURNS_MOCKS)) {
@@ -240,7 +239,7 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testOfflineRoutingUsesLastKey() {
+    void testOfflineRoutingUsesLastKey() {
         // Simulate the player having been online: this caches the storage object and persists lastKey
         sets.setStatistics(false);
         sets.setAdvancements(false);
@@ -265,7 +264,7 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testStoreNotReadyDelegates() {
+    void testStoreNotReadyDelegates() {
         // Provider registered before the store exists (the onEnable window): calls must route to
         // the delegate rather than NPE.
         when(addon.getStore()).thenReturn(null);
@@ -279,7 +278,7 @@ public class InvEconomyTest {
     }
 
     @Test
-    public void testOfflineUnknownWorldDelegates() {
+    void testOfflineUnknownWorldDelegates() {
         // Brand new player, offline, no lastKey -> cannot resolve -> delegate
         when(player.getPlayer()).thenReturn(null);
         when(delegate.depositPlayer(player, 5.0))

--- a/src/test/java/com/wasteofplastic/invswitcher/listeners/PlayerListenerTest.java
+++ b/src/test/java/com/wasteofplastic/invswitcher/listeners/PlayerListenerTest.java
@@ -55,7 +55,7 @@ import world.bentobox.bentobox.util.Util;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class PlayerListenerTest {
+class PlayerListenerTest {
 
     @Mock
     private InvSwitcher addon;
@@ -81,7 +81,7 @@ public class PlayerListenerTest {
     /**
      */
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         // BentoBox static mock (needed for logDebug calls in PlayerListener)
         BentoBox bbPlugin = mock(BentoBox.class);
         mockedBentoBox = Mockito.mockStatic(BentoBox.class);
@@ -105,7 +105,7 @@ public class PlayerListenerTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         if (mockedBentoBox != null) {
             mockedBentoBox.close();
         }
@@ -115,7 +115,7 @@ public class PlayerListenerTest {
      * Test method for {@link com.wasteofplastic.invswitcher.listeners.PlayerListener#PlayerListener(com.wasteofplastic.invswitcher.InvSwitcher)}.
      */
     @Test
-    public void testPlayerListener() {
+    void testPlayerListener() {
         assertNotNull(pl);
     }
 
@@ -123,7 +123,7 @@ public class PlayerListenerTest {
      * Test method for {@link com.wasteofplastic.invswitcher.listeners.PlayerListener#onWorldEnter(org.bukkit.event.player.PlayerChangedWorldEvent)}.
      */
     @Test
-    public void testOnWorldEnterSameWorld() {
+    void testOnWorldEnterSameWorld() {
         PlayerChangedWorldEvent event = new PlayerChangedWorldEvent(player, world);
         pl.onWorldEnter(event);
         verify(store, never()).storeInventory(any(), any());
@@ -134,7 +134,7 @@ public class PlayerListenerTest {
      * Test method for {@link com.wasteofplastic.invswitcher.listeners.PlayerListener#onWorldEnter(org.bukkit.event.player.PlayerChangedWorldEvent)}.
      */
     @Test
-    public void testOnWorldEnterDifferentWorld() {
+    void testOnWorldEnterDifferentWorld() {
         PlayerChangedWorldEvent event = new PlayerChangedWorldEvent(player, notWorld);
         // Mock the static method
         try (MockedStatic<Util> mockedBukkit = mockStatic(Util.class, Mockito.RETURNS_MOCKS)) {
@@ -149,7 +149,7 @@ public class PlayerListenerTest {
      * Test method for {@link com.wasteofplastic.invswitcher.listeners.PlayerListener#onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent)}.
      */
     @Test
-    public void testOnPlayerJoin() {
+    void testOnPlayerJoin() {
         PlayerJoinEvent event = new PlayerJoinEvent(player, "");
         pl.onPlayerJoin(event);
         // No storage yet
@@ -160,7 +160,7 @@ public class PlayerListenerTest {
      * Test method for {@link com.wasteofplastic.invswitcher.listeners.PlayerListener#onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent)}.
      */
     @Test
-    public void testOnPlayerJoinNonHandledWorld() {
+    void testOnPlayerJoinNonHandledWorld() {
         when(player.getWorld()).thenReturn(notWorld);
         PlayerJoinEvent event = new PlayerJoinEvent(player, "");
         pl.onPlayerJoin(event);
@@ -172,7 +172,7 @@ public class PlayerListenerTest {
      * Test method for {@link com.wasteofplastic.invswitcher.listeners.PlayerListener#onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent)}.
      */
     @Test
-    public void testOnPlayerJoinWithStorage() {
+    void testOnPlayerJoinWithStorage() {
         testOnWorldEnterDifferentWorld();
         when(player.getWorld()).thenReturn(notWorld);
         PlayerJoinEvent event = new PlayerJoinEvent(player, "");
@@ -185,7 +185,7 @@ public class PlayerListenerTest {
      * Test method for {@link com.wasteofplastic.invswitcher.listeners.PlayerListener#onPlayerQuit(org.bukkit.event.player.PlayerQuitEvent)}.
      */
     @Test
-    public void testOnPlayerQuit() {
+    void testOnPlayerQuit() {
         PlayerQuitEvent event = new PlayerQuitEvent(player, "");
         pl.onPlayerQuit(event);
         verify(store).storeAndSave(player, world, false);
@@ -196,7 +196,7 @@ public class PlayerListenerTest {
      * Test method for {@link com.wasteofplastic.invswitcher.listeners.PlayerListener#onPlayerQuit(org.bukkit.event.player.PlayerQuitEvent)}.
      */
     @Test
-    public void testOnPlayerQuitNotCoveredWorld() {
+    void testOnPlayerQuitNotCoveredWorld() {
         when(player.getWorld()).thenReturn(notWorld);
         PlayerQuitEvent event = new PlayerQuitEvent(player, "");
         pl.onPlayerQuit(event);
@@ -207,9 +207,8 @@ public class PlayerListenerTest {
     // --- Island Enter Event Tests ---
 
     @Test
-    public void testOnIslandEnterDisabled() {
+    void testOnIslandEnterDisabled() {
         when(settings.isIslandsActive()).thenReturn(false);
-        Island island = mock(Island.class);
         IslandEnterEvent event = new IslandEnterEvent(island, playerUUID, false, null, island, null);
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class)) {
             mockedBukkit.when(() -> Bukkit.getPlayer(playerUUID)).thenReturn(player);
@@ -219,9 +218,8 @@ public class PlayerListenerTest {
     }
 
     @Test
-    public void testOnIslandEnterNotOwner() {
+    void testOnIslandEnterNotOwner() {
         when(settings.isIslandsActive()).thenReturn(true);
-        Island island = mock(Island.class);
         UUID otherOwner = UUID.randomUUID();
         when(island.getOwner()).thenReturn(otherOwner);
         IslandEnterEvent event = new IslandEnterEvent(island, playerUUID, false, null, island, null);
@@ -233,9 +231,8 @@ public class PlayerListenerTest {
     }
 
     @Test
-    public void testOnIslandEnterSingleIsland() {
+    void testOnIslandEnterSingleIsland() {
         when(settings.isIslandsActive()).thenReturn(true);
-        Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(playerUUID);
 
         IslandEnterEvent event = new IslandEnterEvent(island, playerUUID, false, null, island, null);
@@ -250,9 +247,8 @@ public class PlayerListenerTest {
     }
 
     @Test
-    public void testOnIslandEnterMultipleIslandsSameKey() {
+    void testOnIslandEnterMultipleIslandsSameKey() {
         when(settings.isIslandsActive()).thenReturn(true);
-        Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(playerUUID);
         when(island.getUniqueId()).thenReturn("island-1");
 
@@ -273,9 +269,8 @@ public class PlayerListenerTest {
     }
 
     @Test
-    public void testOnIslandEnterMultipleIslandsDifferentKey() {
+    void testOnIslandEnterMultipleIslandsDifferentKey() {
         when(settings.isIslandsActive()).thenReturn(true);
-        Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(playerUUID);
         when(island.getUniqueId()).thenReturn("island-2");
 
@@ -298,7 +293,7 @@ public class PlayerListenerTest {
     // --- Respawn Event Tests ---
 
     @Test
-    public void testOnPlayerRespawnDisabled() {
+    void testOnPlayerRespawnDisabled() {
         when(settings.isIslandsActive()).thenReturn(false);
         Location respawnLoc = mock(Location.class);
         when(respawnLoc.getWorld()).thenReturn(world);
@@ -310,12 +305,11 @@ public class PlayerListenerTest {
     }
 
     @Test
-    public void testOnPlayerRespawnSameIsland() {
+    void testOnPlayerRespawnSameIsland() {
         when(settings.isIslandsActive()).thenReturn(true);
         Location respawnLoc = mock(Location.class);
         when(respawnLoc.getWorld()).thenReturn(world);
 
-        Island island = mock(Island.class);
         when(islandsManager.getIslandAt(respawnLoc)).thenReturn(Optional.of(island));
         when(store.getStorageKey(player, world, island)).thenReturn("world/island-1");
         when(store.getCurrentKey(player)).thenReturn("world/island-1");
@@ -329,12 +323,11 @@ public class PlayerListenerTest {
     }
 
     @Test
-    public void testOnPlayerRespawnDifferentIsland() {
+    void testOnPlayerRespawnDifferentIsland() {
         when(settings.isIslandsActive()).thenReturn(true);
         Location respawnLoc = mock(Location.class);
         when(respawnLoc.getWorld()).thenReturn(world);
 
-        Island island = mock(Island.class);
         when(islandsManager.getIslandAt(respawnLoc)).thenReturn(Optional.of(island));
         when(store.getStorageKey(player, world, island)).thenReturn("world/island-2");
         when(store.getCurrentKey(player)).thenReturn("world/island-1");
@@ -349,7 +342,7 @@ public class PlayerListenerTest {
     }
 
     @Test
-    public void testOnPlayerRespawnNoIsland() {
+    void testOnPlayerRespawnNoIsland() {
         when(settings.isIslandsActive()).thenReturn(true);
         Location respawnLoc = mock(Location.class);
         when(respawnLoc.getWorld()).thenReturn(world);
@@ -370,7 +363,7 @@ public class PlayerListenerTest {
      * and the store clear methods should not be called.
      */
     @Test
-    public void testOnPlayerResetInventoryWorldNotManaged() {
+    void testOnPlayerResetInventoryWorldNotManaged() {
         // notWorld is not in the addon's worlds set
         when(addon.getWorlds()).thenReturn(Set.of(world)); // only 'world' is managed
         PlayerResetInventoryEvent event = new PlayerResetInventoryEvent(notWorld, island, playerUUID);
@@ -386,7 +379,7 @@ public class PlayerListenerTest {
      * When the player is offline, the event should not be intercepted.
      */
     @Test
-    public void testOnPlayerResetInventoryPlayerOffline() {
+    void testOnPlayerResetInventoryPlayerOffline() {
         PlayerResetInventoryEvent event = new PlayerResetInventoryEvent(world, island, playerUUID);
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class)) {
             mockedBukkit.when(() -> Bukkit.getPlayer(playerUUID)).thenReturn(null); // offline
@@ -400,7 +393,7 @@ public class PlayerListenerTest {
      * When the player is currently in the event world, BentoBox should handle the reset directly.
      */
     @Test
-    public void testOnPlayerResetInventoryPlayerInEventWorld() {
+    void testOnPlayerResetInventoryPlayerInEventWorld() {
         // player.getWorld() returns 'world', event world is also 'world'
         when(player.getWorld()).thenReturn(world);
         PlayerResetInventoryEvent event = new PlayerResetInventoryEvent(world, island, playerUUID);
@@ -419,7 +412,7 @@ public class PlayerListenerTest {
      * and the stored inventory for the BentoBox world should be cleared.
      */
     @Test
-    public void testOnPlayerResetInventoryPlayerInDifferentWorld() {
+    void testOnPlayerResetInventoryPlayerInDifferentWorld() {
         when(settings.isInventory()).thenReturn(true);
         // player is in notWorld, event fires for world
         when(player.getWorld()).thenReturn(notWorld);
@@ -439,7 +432,7 @@ public class PlayerListenerTest {
      * BentoBox - otherwise the reset would be cancelled and never performed.
      */
     @Test
-    public void testOnPlayerResetInventoryNotInterceptedWhenSwitchingDisabled() {
+    void testOnPlayerResetInventoryNotInterceptedWhenSwitchingDisabled() {
         when(settings.isInventory()).thenReturn(false);
         when(player.getWorld()).thenReturn(notWorld);
         PlayerResetInventoryEvent event = new PlayerResetInventoryEvent(world, island, playerUUID);
@@ -452,7 +445,7 @@ public class PlayerListenerTest {
      * Ender chest reset should be intercepted when the player is in a different world.
      */
     @Test
-    public void testOnPlayerResetEnderChestPlayerInDifferentWorld() {
+    void testOnPlayerResetEnderChestPlayerInDifferentWorld() {
         when(settings.isEnderChest()).thenReturn(true);
         when(player.getWorld()).thenReturn(notWorld);
         PlayerResetEnderChestEvent event = new PlayerResetEnderChestEvent(world, island, playerUUID);
@@ -470,7 +463,7 @@ public class PlayerListenerTest {
      * Ender chest reset should not be intercepted when the player is in the event world.
      */
     @Test
-    public void testOnPlayerResetEnderChestPlayerInEventWorld() {
+    void testOnPlayerResetEnderChestPlayerInEventWorld() {
         when(player.getWorld()).thenReturn(world);
         PlayerResetEnderChestEvent event = new PlayerResetEnderChestEvent(world, island, playerUUID);
         try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class);
@@ -487,7 +480,7 @@ public class PlayerListenerTest {
      * Experience reset should be intercepted when the player is in a different world.
      */
     @Test
-    public void testOnPlayerResetExpPlayerInDifferentWorld() {
+    void testOnPlayerResetExpPlayerInDifferentWorld() {
         when(settings.isExperience()).thenReturn(true);
         when(player.getWorld()).thenReturn(notWorld);
         PlayerResetExpEvent event = new PlayerResetExpEvent(world, island, playerUUID);
@@ -505,7 +498,7 @@ public class PlayerListenerTest {
      * Health reset should be intercepted when the player is in a different world.
      */
     @Test
-    public void testOnPlayerResetHealthPlayerInDifferentWorld() {
+    void testOnPlayerResetHealthPlayerInDifferentWorld() {
         when(settings.isHealth()).thenReturn(true);
         when(player.getWorld()).thenReturn(notWorld);
         PlayerResetHealthEvent event = new PlayerResetHealthEvent(world, island, playerUUID);
@@ -523,7 +516,7 @@ public class PlayerListenerTest {
      * Hunger reset should be intercepted when the player is in a different world.
      */
     @Test
-    public void testOnPlayerResetHungerPlayerInDifferentWorld() {
+    void testOnPlayerResetHungerPlayerInDifferentWorld() {
         when(settings.isFood()).thenReturn(true);
         when(player.getWorld()).thenReturn(notWorld);
         PlayerResetHungerEvent event = new PlayerResetHungerEvent(world, island, playerUUID);
@@ -541,7 +534,7 @@ public class PlayerListenerTest {
      * Money reset should be intercepted when the player is in a different world.
      */
     @Test
-    public void testOnPlayerResetMoneyPlayerInDifferentWorld() {
+    void testOnPlayerResetMoneyPlayerInDifferentWorld() {
         when(settings.isMoney()).thenReturn(true);
         when(player.getWorld()).thenReturn(notWorld);
         PlayerResetMoneyEvent event = new PlayerResetMoneyEvent(world, island, playerUUID);
@@ -560,7 +553,7 @@ public class PlayerListenerTest {
      * because BentoBox's reset routes correctly through InvSwitcher's economy.
      */
     @Test
-    public void testOnPlayerResetMoneyPlayerInEventWorld() {
+    void testOnPlayerResetMoneyPlayerInEventWorld() {
         when(settings.isMoney()).thenReturn(true);
         when(player.getWorld()).thenReturn(world);
         PlayerResetMoneyEvent event = new PlayerResetMoneyEvent(world, island, playerUUID);
@@ -578,7 +571,7 @@ public class PlayerListenerTest {
      * Money reset should be ignored entirely when InvSwitcher money is disabled.
      */
     @Test
-    public void testOnPlayerResetMoneyMoneyDisabled() {
+    void testOnPlayerResetMoneyMoneyDisabled() {
         when(settings.isMoney()).thenReturn(false);
         when(player.getWorld()).thenReturn(notWorld);
         PlayerResetMoneyEvent event = new PlayerResetMoneyEvent(world, island, playerUUID);


### PR DESCRIPTION
Release 1.19.0.

## Highlights

### Standalone economy now works without a separate economy plugin
`fix: register a fresh VaultHook when BentoBox has none` — InvSwitcher registers its own per-world Vault economy, but BentoBox hooks Vault during early hooks (before addons enable). When InvSwitcher was the only economy, that early hook failed and was discarded, so `getVault()` stayed empty and economy-dependent addons (e.g. Bank) disabled themselves with "Vault is required". InvSwitcher now registers a fresh `VaultHook` once its provider is live, so it works as a standalone economy.

_Companion PRs harden this on the framework side: BentoBoxWorld/BentoBox#2995 (retry the Vault hook after addons enable) and BentoBoxWorld/Bank#67 (retry before disabling)._

### Correct balance reported for offline economy transactions
`fix: report offline economy balances correctly and harden offline saves` — admin `eco give`/`set`/`take` on an offline player reported a stale balance (e.g. "New balance: 0.00" after giving 2000) because the success message re-read the balance from the database before the asynchronous save had flushed. The commands now report the authoritative balance returned by the transaction itself.

The same change hardens the underlying offline read-after-write path: offline saves are tracked in flight so two rapid sequential transactions can't load independent stale copies and lose an update — without blocking the main thread or caching offline players indefinitely. Adds a regression test.

## Commits
- `d929649` fix: register a fresh VaultHook when BentoBox has none
- `a15c645` fix: report offline economy balances correctly and harden offline saves
- `f1bd4c2` chore: bump version to 1.19.0

Full test suite: 124/124 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)