### PR TITLE
Fix per-island health death loop on respawn (#56)

### DIFF
--- a/src/main/java/com/wasteofplastic/invswitcher/Store.java
+++ b/src/main/java/com/wasteofplastic/invswitcher/Store.java
@@ -304,16 +304,22 @@ public class Store {
     }
 
     private void setHeath(InventoryStorage store, Player player, String overworldName) {
-        // Health
-        double health = store.getHealth().getOrDefault(overworldName,
-                player.getAttribute(Attribute.MAX_HEALTH).getValue());
-
         AttributeInstance attr = player.getAttribute(Attribute.MAX_HEALTH);
-        if (attr != null && health > attr.getValue()) {
-            health = attr.getValue();
+        double maxHealth = (attr != null) ? attr.getValue() : 20D;
+
+        // Health
+        double health = store.getHealth().getOrDefault(overworldName, maxHealth);
+
+        if (health > maxHealth) {
+            health = maxHealth;
         }
-        if (health < 0D) {
-            health = 0D;
+        // Never load a fatal health value. A stored value of 0 (or less) only arises when the
+        // player's state was captured mid-death (e.g. when they died on another island). Applying
+        // it to a live player would kill them again the moment they load the world, causing an
+        // endless respawn/death loop (issue #56). Restore full health instead, matching vanilla
+        // respawn behaviour.
+        if (health <= 0D) {
+            health = maxHealth;
         }
         player.setHealth(health);
 

--- a/src/test/java/com/wasteofplastic/invswitcher/StoreTest.java
+++ b/src/test/java/com/wasteofplastic/invswitcher/StoreTest.java
@@ -207,6 +207,29 @@ class StoreTest {
     }
 
     /**
+     * Issue #56: a stored health of 0 is only ever captured when the player's state is saved
+     * mid-death (e.g. per-island health enabled and the player died on another island). Loading
+     * that value into a live player would kill them the instant they enter the world, causing an
+     * endless respawn/death loop. Loading must restore full health instead of applying 0.
+     */
+    @Test
+    void testGetInventoryNeverLoadsFatalHealth() {
+        sets.setStatistics(false);
+        sets.setAdvancements(false);
+
+        // Simulate the player's state being captured mid-death with 0 health
+        when(player.getHealth()).thenReturn(0D);
+        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS)) {
+            s.storeInventory(player, world);
+        }
+
+        // Re-entering the world must restore full health (max = 18), never the fatal stored 0
+        s.getInventory(player, world);
+        verify(player).setHealth(18D);
+        verify(player, never()).setHealth(0D);
+    }
+
+    /**
      * Test that advancement grants during {@link Store#getInventory} do not modify the player's
      * experience points. Some advancements reward XP when their criteria are awarded; the store
      * must save and restore XP around the advancement grant step.


### PR DESCRIPTION
Fixes #56

## Problem
With **per-island health** enabled and a player owning multiple islands, dying on an island softlocked the player: they respawned at their default island and every attempt to return produced another death screen because their health was stuck at 0.

## Root cause
On death/respawn the player's state is captured mid-death (health `0`) and saved to the death island's storage key. When the player later loads that island, `Store.setHeath` applied the stored `0` via `player.setHealth(0)`, killing them instantly and re-triggering the death screen — an endless respawn/death loop.

A stored health of `0` is never a valid value to load into a live player; it can only ever arise from a mid-death capture.

## Fix
`Store.setHeath` now restores full (max) health whenever the resolved value is `<= 0`, matching vanilla respawn behaviour, and still clamps against max health as before.

## Testing
- Added `StoreTest#testGetInventoryNeverLoadsFatalHealth` reproducing the fatal-health load.
- Full suite: 125 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)