### PR TITLE
Release 1.19.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
 # InvSwitcher — .github/workflows/publish.yml
-# Publishes the jar attached to a GitHub release to CurseForge (and Hangar once a
-# slug is set) via the shared BentoBoxWorld/.github reusable workflow. It downloads
-# the release asset rather than rebuilding from source, so a dependency-repo outage
-# can't block publishing. Includes workflow_dispatch to (re)publish a given version.
+# Publishes the jar attached to a GitHub release to CurseForge and Hangar via the
+# shared BentoBoxWorld/.github reusable workflow. Downloads the release asset instead of
+# rebuilding from source. The reusable workflow is pinned to a commit SHA (Sonar
+# githubactions:S7637). workflow_dispatch lets you (re)publish a given version.
 
-name: Publish release to CurseForge
+name: Publish release to CurseForge and Hangar
 
 on:
   release:
@@ -18,10 +18,10 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@e0c5d98f5e6ef9ea7c9a28afad05f4c07bcde898 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
-      hangar_slug: ""                    # set the Hangar project slug to enable Hangar publishing
+      hangar_slug: "InvSwitcher"           # blank = skip Hangar
       curseforge_id: "1515498"
       game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
       version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,30 @@
 # InvSwitcher — .github/workflows/publish.yml
-# CurseForge-first rollout. Hangar left blank; add its slug later to enable Hangar.
+# Publishes the jar attached to a GitHub release to CurseForge (and Hangar once a
+# slug is set) via the shared BentoBoxWorld/.github reusable workflow. It downloads
+# the release asset rather than rebuilding from source, so a dependency-repo outage
+# can't block publishing. Includes workflow_dispatch to (re)publish a given version.
 
-name: Publish release
+name: Publish release to CurseForge
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.2.3)"
+        required: true
+        type: string
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@main
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@master
     with:
-      hangar_slug: ""
+      use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
+      hangar_slug: ""                    # set the Hangar project slug to enable Hangar publishing
       curseforge_id: "1515498"
-      game_versions: "26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6"
+      game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
+      version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag
     secrets:
       HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
       CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@e0c5d98f5e6ef9ea7c9a28afad05f4c07bcde898 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@71bf927bce32586216baa6995f21852d944b98b9 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "InvSwitcher"           # blank = skip Hangar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@71bf927bce32586216baa6995f21852d944b98b9 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@fe4b1f03c19f4fd4212020a06a07a7097923adec # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "InvSwitcher"           # blank = skip Hangar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+# InvSwitcher — .github/workflows/publish.yml
+# CurseForge-first rollout. Hangar left blank; add its slug later to enable Hangar.
+
+name: Publish release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@main
+    with:
+      hangar_slug: ""
+      curseforge_id: "1515498"
+      game_versions: "26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6"
+    secrets:
+      HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
+      CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.19.0</build.version>
+        <build.version>1.19.1</build.version>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_addon-invSwitcher</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/src/main/java/com/wasteofplastic/invswitcher/Store.java
+++ b/src/main/java/com/wasteofplastic/invswitcher/Store.java
@@ -304,16 +304,22 @@ public class Store {
     }
 
     private void setHeath(InventoryStorage store, Player player, String overworldName) {
-        // Health
-        double health = store.getHealth().getOrDefault(overworldName,
-                player.getAttribute(Attribute.MAX_HEALTH).getValue());
-
         AttributeInstance attr = player.getAttribute(Attribute.MAX_HEALTH);
-        if (attr != null && health > attr.getValue()) {
-            health = attr.getValue();
+        double maxHealth = (attr != null) ? attr.getValue() : 20D;
+
+        // Health
+        double health = store.getHealth().getOrDefault(overworldName, maxHealth);
+
+        if (health > maxHealth) {
+            health = maxHealth;
         }
-        if (health < 0D) {
-            health = 0D;
+        // Never load a fatal health value. A stored value of 0 (or less) only arises when the
+        // player's state was captured mid-death (e.g. when they died on another island). Applying
+        // it to a live player would kill them again the moment they load the world, causing an
+        // endless respawn/death loop (issue #56). Restore full health instead, matching vanilla
+        // respawn behaviour.
+        if (health <= 0D) {
+            health = maxHealth;
         }
         player.setHealth(health);
 

--- a/src/test/java/com/wasteofplastic/invswitcher/StoreTest.java
+++ b/src/test/java/com/wasteofplastic/invswitcher/StoreTest.java
@@ -207,6 +207,29 @@ class StoreTest {
     }
 
     /**
+     * Issue #56: a stored health of 0 is only ever captured when the player's state is saved
+     * mid-death (e.g. per-island health enabled and the player died on another island). Loading
+     * that value into a live player would kill them the instant they enter the world, causing an
+     * endless respawn/death loop. Loading must restore full health instead of applying 0.
+     */
+    @Test
+    void testGetInventoryNeverLoadsFatalHealth() {
+        sets.setStatistics(false);
+        sets.setAdvancements(false);
+
+        // Simulate the player's state being captured mid-death with 0 health
+        when(player.getHealth()).thenReturn(0D);
+        try (MockedStatic<Bukkit> mockedBukkit = mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS)) {
+            s.storeInventory(player, world);
+        }
+
+        // Re-entering the world must restore full health (max = 18), never the fatal stored 0
+        s.getInventory(player, world);
+        verify(player).setHealth(18D);
+        verify(player, never()).setHealth(0D);
+    }
+
+    /**
      * Test that advancement grants during {@link Store#getInventory} do not modify the player's
      * experience points. Some advancements reward XP when their criteria are awarded; the store
      * must save and restore XP around the advancement grant step.


### PR DESCRIPTION
Release **1.19.1** — merge `develop` into `master`.

## Changes since 1.19.0

### Bug fixes
- **Fix per-island health death loop on respawn (#56).** With per-island health enabled, a player who owned multiple islands could get stuck in an endless respawn/death screen after dying. `Store.setHeath` no longer applies a fatal stored health of `0` (only ever captured mid-death) to a live player — it restores full health instead. (#57)

### CI / build
- Add CurseForge publish workflow and enable Hangar publishing.
- Pin the reusable publish workflow to a SHA and bump it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)